### PR TITLE
Fixed code causing seeding to duplicate TaskIncidents

### DIFF
--- a/embc-app/DataInterfaces/IncidentTaskExtensions.cs
+++ b/embc-app/DataInterfaces/IncidentTaskExtensions.cs
@@ -60,7 +60,7 @@ namespace Gov.Jag.Embc.Public.DataInterfaces
         /// </summary>
         private static void AddInitialIncidentTask(this EmbcDbContext context, IncidentTask initialIncidentTask)
         {
-            IncidentTask IncidentTask = context.GetIncidentTaskByTaskNumber(initialIncidentTask.Details);
+            IncidentTask IncidentTask = context.GetIncidentTaskByTaskNumber(initialIncidentTask.TaskNumber);
             if (IncidentTask != null)
             {
                 return;


### PR DESCRIPTION
Tiny fix to prevent all the extra incidents being seeded every deploy