### PR TITLE
Frontent UAT fixes

### DIFF
--- a/embc-app/ClientApp/src/app/evacuee-registration/evacuee-registration-one/evacuee-registration-one.component.html
+++ b/embc-app/ClientApp/src/app/evacuee-registration/evacuee-registration-one/evacuee-registration-one.component.html
@@ -1,11 +1,3 @@
-<!--
-  TODO:
-  "control.registeronchange is not a function"
-
-  this bug is seen in the console. Unfortunately by commenting things out this simply moves the error location around the code. This seems to be potentially a bug with patching formArrays. (According to stack overflow.) Maybe this will come out in the wash? Revisit this later when we have more time to spend on a single non-breaking error.
- -->
-
-
 <div class="mb-4">
   <h1>{{pageTitle}}</h1>
   <p *ngIf="createMode">
@@ -338,8 +330,7 @@
       </div>
       <div class="form-row">
         <div class="col">
-          <textarea [class.is-invalid]="invalid('disasterAffectDetails')" class="form-control" formControlName="disasterAffectDetails" placeholder="Please specify" rows="4"></textarea>
-          <span *ngIf="submitted" class="invalid-feedback">{{e.disasterAffectDetails}}</span>
+          <textarea class="form-control" formControlName="disasterAffectDetails" placeholder="Please specify" rows="4"></textarea>
         </div>
       </div>
     </div>
@@ -520,14 +511,13 @@
       </h3>
       <div class="form-row">
         <app-attention-icon [alignCenter]="false"></app-attention-icon>
-        <p class="required">
+        <p>
           ESS (Emergency Support Services) provides short term assistance to give you and your family a chance to
           recover.<br>
           Have you thought about what you will do after that time?
         </p>
       </div>
-      <textarea [class.is-invalid]="invalid('familyRecoveryPlan')" class="form-control" placeholder="Details" rows="4" formControlName="familyRecoveryPlan"></textarea>
-      <span *ngIf="submitted" class="invalid-feedback">{{e.familyRecoveryPlan}}</span>
+      <textarea class="form-control" placeholder="Details" rows="4" formControlName="familyRecoveryPlan"></textarea>
     </div>
 
     <!-- Follow up -->

--- a/embc-app/ClientApp/src/app/evacuee-registration/evacuee-registration-one/evacuee-registration-one.component.ts
+++ b/embc-app/ClientApp/src/app/evacuee-registration/evacuee-registration-one/evacuee-registration-one.component.ts
@@ -115,17 +115,11 @@ export class EvacueeRegistrationOneComponent implements OnInit {
       mailingAddressInBC: {
         required: 'Please make a selection regarding your mailing address.',
       },
-      disasterAffectDetails: {
-        required: 'Please enter a brief statement of how the evacuee/family were affected by the disaster.',
-      },
       insuranceCode: {
         required: 'Please make a selection regarding insurance coverage.',
       },
       dietaryNeeds: {
         required: 'Please make a selection regarding dietary requirements.',
-      },
-      dietaryNeedsDetails: {
-        required: 'Please specify details regarding dietary requirements.',
       },
       medicationNeeds: {
         required: 'Please make a selection regarding medication.',
@@ -138,9 +132,6 @@ export class EvacueeRegistrationOneComponent implements OnInit {
       },
       requiresSupport: {
         required: 'Please select whether supports are required.',
-      },
-      familyRecoveryPlan: {
-        required: 'Please enter details of the evacuee(s) long term plans.',
       },
     };
     // TODO: Wow. it sure would be nice if we could just instatiate a class instead of using interfaces
@@ -279,12 +270,12 @@ export class EvacueeRegistrationOneComponent implements OnInit {
       restrictedAccess: false,
       essFileNumber: null,
       dietaryNeeds: [null, Validators.required],
-      dietaryNeedsDetails: [null, CustomValidators.requiredWhenTrue('dietaryNeeds')],
-      disasterAffectDetails: [null, Validators.required],
+      dietaryNeedsDetails: [null],
+      disasterAffectDetails: [null],
       externalReferralsDetails: '',
       facility: [null, Validators.required],
-      familyRecoveryPlan: [null, Validators.required],
-      followUpDetails: '',
+      familyRecoveryPlan: [null],
+      followUpDetails: [null],
       insuranceCode: [null, Validators.required],  // one of ['yes', 'yes-unsure', 'no', 'unsure']
       medicationNeeds: [null, Validators.required],
       selfRegisteredDate: null,

--- a/embc-app/ClientApp/src/app/shared/components/address-form/address-selector.component.ts
+++ b/embc-app/ClientApp/src/app/shared/components/address-form/address-selector.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, OnInit, Input, OnChanges, SimpleChanges, OnDestroy } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { Store } from '@ngrx/store';
 
@@ -14,7 +14,7 @@ import { map } from 'rxjs/operators';
   `,
   styles: []
 })
-export class AddressSelectorComponent implements OnInit, OnChanges {
+export class AddressSelectorComponent implements OnInit, OnChanges, OnDestroy {
   @Input() parent: FormGroup;
   @Input() withinBC = true;
   @Input() touched = false;
@@ -23,6 +23,9 @@ export class AddressSelectorComponent implements OnInit, OnChanges {
   countries$ = this.store.select(state => state.lookups.countries.countries);
   // Find out the country ID for Canada as it is hard-coded for BC addresses...
   canada$ = this.countries$.pipe(map(countries => countries.find(x => x.name === 'Canada')));
+
+  // convenience getter for easy access to form fields
+  get f() { return this.parent.controls; }
 
   constructor(private store: Store<AppState>) { }
 
@@ -35,6 +38,25 @@ export class AddressSelectorComponent implements OnInit, OnChanges {
       this.canada$.subscribe(canada => this.toggleAddressForm(withinBC, canada));
     }
   }
+
+  ngOnDestroy(): void {
+    this.f.addressLine1.clearValidators();
+    this.f.postalCode.clearValidators();
+    this.f.community.clearValidators();
+    this.f.city.clearValidators();
+    this.f.province.clearValidators();
+    this.f.country.clearValidators();
+
+    this.f.addressLine1.updateValueAndValidity();
+    this.f.postalCode.updateValueAndValidity();
+    this.f.community.updateValueAndValidity();
+    this.f.city.updateValueAndValidity();
+    this.f.province.updateValueAndValidity();
+    this.f.country.updateValueAndValidity();
+
+    this.parent.updateValueAndValidity();
+  }
+
 
   private toggleAddressForm(withinBC: boolean, homeCountry: Country): void {
     const values = withinBC

--- a/embc-app/ClientApp/src/app/shared/components/address-form/bc-address/bc-address.component.ts
+++ b/embc-app/ClientApp/src/app/shared/components/address-form/bc-address/bc-address.component.ts
@@ -70,11 +70,23 @@ export class BcAddressComponent implements OnInit {
 
   private setupValidation(): void {
     this.f.addressLine1.setValidators([Validators.required]);
+    this.f.addressLine1.updateValueAndValidity();
+
     this.f.postalCode.setValidators([CustomValidators.postalCodeCanada]);
+    this.f.postalCode.updateValueAndValidity();
+
     this.f.community.setValidators([Validators.required]);
-    this.f.city.setValidators(null);
+    this.f.community.updateValueAndValidity();
+
+    this.f.city.clearValidators();
+    this.f.city.updateValueAndValidity();
+
     this.f.province.setValidators([Validators.required]);
+    this.f.province.updateValueAndValidity();
+
     this.f.country.setValidators([Validators.required]);
+    this.f.country.updateValueAndValidity();
+
     this.parent.updateValueAndValidity();
   }
 }

--- a/embc-app/ClientApp/src/app/shared/components/address-form/other-address/other-address.component.ts
+++ b/embc-app/ClientApp/src/app/shared/components/address-form/other-address/other-address.component.ts
@@ -69,11 +69,23 @@ export class OtherAddressComponent implements OnInit {
 
   private setupValidation(): void {
     this.f.addressLine1.setValidators([Validators.required]);
-    this.f.postalCode.setValidators(null);
-    this.f.community.setValidators(null);
+    this.f.addressLine1.updateValueAndValidity();
+
+    this.f.postalCode.clearValidators();
+    this.f.postalCode.updateValueAndValidity();
+
+    this.f.community.clearValidators();
+    this.f.community.updateValueAndValidity();
+
     this.f.city.setValidators([Validators.required]);
-    this.f.province.setValidators(null);
+    this.f.city.updateValueAndValidity();
+
+    this.f.province.clearValidators();
+    this.f.province.updateValueAndValidity();
+
     this.f.country.setValidators([Validators.required]);
+    this.f.country.updateValueAndValidity();
+
     this.parent.updateValueAndValidity();
   }
 }


### PR DESCRIPTION
* Make all free form fields optional in evacuee form
* Clear address validators when control is destroyed
  This fixes a bug when switching "mailing address" to not same as main address and then back to yes