### PR TITLE
Set model Community.RegionName to required

### DIFF
--- a/embc-app/Migrations/20190502053607_Set-Community-RegionName-Not-Null.Designer.cs
+++ b/embc-app/Migrations/20190502053607_Set-Community-RegionName-Not-Null.Designer.cs
@@ -4,14 +4,16 @@ using Gov.Jag.Embc.Public.DataInterfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Gov.Jag.Embc.Public.Migrations
 {
     [DbContext(typeof(EmbcDbContext))]
-    partial class EmbcDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190502053607_Set-Community-RegionName-Not-Null")]
+    partial class SetCommunityRegionNameNotNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/embc-app/Migrations/20190502053607_Set-Community-RegionName-Not-Null.cs
+++ b/embc-app/Migrations/20190502053607_Set-Community-RegionName-Not-Null.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Gov.Jag.Embc.Public.Migrations
+{
+    public partial class SetCommunityRegionNameNotNull : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Communities_Regions_RegionName",
+                table: "Communities");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RegionName",
+                table: "Communities",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Communities_Regions_RegionName",
+                table: "Communities",
+                column: "RegionName",
+                principalTable: "Regions",
+                principalColumn: "Name",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Communities_Regions_RegionName",
+                table: "Communities");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "RegionName",
+                table: "Communities",
+                nullable: true,
+                oldClrType: typeof(string));
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Communities_Regions_RegionName",
+                table: "Communities",
+                column: "RegionName",
+                principalTable: "Regions",
+                principalColumn: "Name",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/embc-app/Models/Db/Community.cs
+++ b/embc-app/Models/Db/Community.cs
@@ -16,6 +16,7 @@ namespace Gov.Jag.Embc.Public.Models.Db
 
         public bool Active { get; set; }
         [ForeignKey("Region")]
+        [Required]
         public string RegionName { get; set; }
         public Region Region { get; set; }
         public IEnumerable<Organization> Organizations { get; set; }

--- a/embc-app/Seeder/SeederRepository.cs
+++ b/embc-app/Seeder/SeederRepository.cs
@@ -74,10 +74,29 @@ namespace Gov.Jag.Embc.Public.Seeder
         {
             var existingEntities = db.Communities
                 .Where(ex =>
-                            communities.Exists(c => ex.Name.Equals(c.Name, StringComparison.OrdinalIgnoreCase) && c.RegionName == ex.RegionName)).ToList();
+                            communities.Exists(
+                                c => ex.Name.Equals(c.Name, StringComparison.OrdinalIgnoreCase) &&
+                                (
+                                    (!string.IsNullOrEmpty(ex.RegionName) && c.RegionName == ex.RegionName) || string.IsNullOrEmpty(ex.RegionName)
+                                )
+                            )
+                ).ToList();
+
             foreach (var entity in existingEntities)
             {
-                var updatedCommunity = communities.Single(c => c.Name.Equals(entity.Name, StringComparison.OrdinalIgnoreCase) && c.RegionName == entity.RegionName);
+                var updatedCommunity = default(Community);
+                if (!string.IsNullOrEmpty(entity.RegionName))
+                {
+                    updatedCommunity = communities.Single(c => c.Name.Equals(entity.Name, StringComparison.OrdinalIgnoreCase) &&
+                                                                                                c.RegionName == entity.RegionName);
+                }
+                else
+                {
+                    updatedCommunity = communities.First(c => c.Name.Equals(entity.Name, StringComparison.OrdinalIgnoreCase) &&
+                                                                                               !existingEntities.Exists(ex => ex.Name.Equals(c.Name, StringComparison.OrdinalIgnoreCase) && 
+                                                                                                        !string.IsNullOrEmpty(ex.RegionName) && c.RegionName == ex.RegionName));
+                }
+
                 entity.Name = updatedCommunity.Name;
                 entity.Active = updatedCommunity.Active;
                 entity.RegionName = updatedCommunity.RegionName;


### PR DESCRIPTION
This fix will ensure that the region name of a Community is not nullable and the change to the SeederRepository is to prevent the creation of duplicated communities if a existing community has a null RegionName.

This in total should fix Communities in the database with a null RegionName via the Seeder and DDL of the Migration scripting.