### PR TITLE
Add logic to header.component to configure volunteer display name

### DIFF
--- a/embc-app/ClientApp/src/app/shared/components/header/header.component.html
+++ b/embc-app/ClientApp/src/app/shared/components/header/header.component.html
@@ -8,7 +8,7 @@
           height="45" alt="B.C. Government Logo">
       </a>
       <span class="navbar-text" *ngIf="currentUser">
-        <span>{{currentUser.name}}</span>
+        <span>{{this.displayName}}</span>
         &nbsp;
         <a href="/logout">Sign Out</a>
       </span>

--- a/embc-app/ClientApp/src/app/shared/components/header/header.component.ts
+++ b/embc-app/ClientApp/src/app/shared/components/header/header.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, SimpleChange, OnChanges } from '@angular/core';
 import { Router } from '@angular/router';
 import { User } from 'src/app/core/models';
 import { AuthService } from 'src/app/core/services/auth.service';
@@ -10,13 +10,50 @@ import { AuthService } from 'src/app/core/services/auth.service';
 })
 export class HeaderComponent implements OnInit {
   @Input() currentUser: User;
-
+  displayName: string = null;
   constructor(
     private router: Router,
     private authService: AuthService
   ) { }
 
   ngOnInit() {
+  }
+
+  ngOnChanges(changes: SimpleChange) {
+    if (this.displayName == null && this.currentUser !== null) {
+      // Separated by spaces... usually
+      let spaceSplit: string[] = this.currentUser.name.split(' ');
+      let commaSplit: string[] = this.currentUser.name.split(',');
+      if (spaceSplit.length >= 2) {
+        this.generateDisplayName(spaceSplit);
+      }
+      // Try splitting on commas
+      else if (commaSplit.length >= 2) {
+        this.generateDisplayName(commaSplit);
+      }
+      // Just use the name
+      else {
+        this.displayName = this.currentUser.name;
+      }
+    }
+  }
+
+  private generateDisplayName(nameArray: string[]) {
+    let fName: string = null;
+    let lName: string = null;
+    if (nameArray.length >= 2) {
+      fName = nameArray[0];
+      lName = nameArray[1];
+      if (lName.length >= 1) {
+        lName = lName.substr(0, 1);
+      }
+      this.displayName = `${fName} ${lName}`;
+      // Clean up any uneeded commas
+      this.displayName = this.displayName.replace(',', '');
+    }
+    else if (nameArray.length === 1) {
+      this.displayName = nameArray[0];
+    }
   }
 
   homeButton() {


### PR DESCRIPTION
Added code into the header component to build a display name as per user requirements. 

**Notes:**
Generally works alright - 2/3 BCeID users I've tested with have their names displayed like _Foo B_, but one BCeID user's (Keycloak) displayName property is only their last name so there is nothing to split the string on (in this case I just display the name as is). Also, my IDIR account reverses the last and first name so I show up as _Reid W_. If IDIR accounts always return this way we can add logic to fix this backwardness, but I don't know if that's an assumption I can make.

