### PR TITLE
Change Host Community label to Support Community

### DIFF
--- a/embc-app/ClientApp/src/app/provincial-admin/components/task-number-list/task-number-list.component.html
+++ b/embc-app/ClientApp/src/app/provincial-admin/components/task-number-list/task-number-list.component.html
@@ -36,7 +36,7 @@
     <table class="table table-hover table-sm">
       <thead class="thead-light">
         <th scope="col text-uppercase">Task Number</th>
-        <th scope="col text-uppercase">Host Community</th>
+        <th scope="col text-uppercase">Support Community</th>
         <th scope="col text-uppercase"># Associated Evacuees</th>
         <th scope="col text-uppercase">Action</th>
       </thead>

--- a/embc-app/ClientApp/src/app/provincial-admin/components/task-number-maker/task-number-maker.component.html
+++ b/embc-app/ClientApp/src/app/provincial-admin/components/task-number-maker/task-number-maker.component.html
@@ -20,7 +20,7 @@
       </div>
       <div class="row">
         <div class="col mb-4">
-          <label class="required" for="community">Host Community</label>
+          <label class="required" for="community">Support Community</label>
           <app-communities-select [class.is-invalid]="invalid('community')" [myParent]="form" myFormControlName="community" myId="community" [myRequired]="true"></app-communities-select>
           <span class="invalid-feedback">Please select a community/region from the dropdown list where the incident took place</span>
         </div>
@@ -110,7 +110,7 @@
           <span class="value">{{incidentTask.taskNumber}}</span>
         </li>
         <li>
-          <span class="name">Host Community:</span>
+          <span class="name">Support Community:</span>
           <span class="value">{{incidentTask.community.name}}</span>
         </li>
         <li>


### PR DESCRIPTION
Super critical and dangerous change that will require hours of testing and work to properly integrate.

Just kidding; changed Host Community to Support Community in a few places.