### PR TITLE
Clear cached registration Id when clicking New Evacuee Registration link

### DIFF
--- a/embc-app/ClientApp/src/app/components/top-navbar/top-navbar.component.html
+++ b/embc-app/ClientApp/src/app/components/top-navbar/top-navbar.component.html
@@ -12,7 +12,7 @@
             [routerLink]="['/volunteer/registrations']" title="Go to Evacuee Search">Evacuee Search</a>
         </li>
         <li class="nav-item">
-          <a [class.active]="router.url==='/volunteer/registration'" class='nav-link'
+          <a [class.active]="router.url==='/volunteer/registration'" class='nav-link' (click)="clearCachedKey()"
             [routerLink]="['/volunteer/registration']" title="Go to New Evacuee Reigstration">New Evacuee Registration</a>
         </li>
         <li class="nav-item">

--- a/embc-app/ClientApp/src/app/components/top-navbar/top-navbar.component.ts
+++ b/embc-app/ClientApp/src/app/components/top-navbar/top-navbar.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { PROVINCIAL_ADMIN, LOCAL_AUTHORITY, VOLUNTEER } from 'src/app/constants';
 import { Router } from '@angular/router';
+import { UniqueKeyService } from 'src/app/core/services/unique-key.service';
 
 @Component({
   selector: 'app-top-navbar',
@@ -22,7 +23,8 @@ export class TopNavbarComponent implements OnInit {
 
   constructor(
     private authService: AuthService,
-    public router: Router // used in HTML
+    public router: Router, // used in HTML
+    private uniqueKeyService: UniqueKeyService
   ) { }
 
   ngOnInit() {
@@ -45,4 +47,11 @@ export class TopNavbarComponent implements OnInit {
       this.navbarSupportedContent.nativeElement.classList.add('collapse');
     }
   }
+
+  // Clear out any stored registration Id - when the link is clicked we're always going to be doing a new one.
+  clearCachedKey() {
+    this.uniqueKeyService.clearKey();
+  }
+
+
 }


### PR DESCRIPTION
Fixed a bug where if you were viewing the details of a registration and then clicked the "New Evacuee Registration" link you'd instead be editing the details of your last viewed registration.