### PR TITLE
Referral pdf updates

### DIFF
--- a/embc-app/Services/Referrals/ReferralsService.cs
+++ b/embc-app/Services/Referrals/ReferralsService.cs
@@ -101,7 +101,6 @@ namespace Gov.Jag.Embc.Public.Services.Referrals
             
             referral.VolunteerDisplayName = userService.GetDisplayName();
             // If we're in prod, we don't want the watermark
-            var foo = env.IsProduction(); // do this work????????
             referral.DisplayWatermark = !env.IsProduction();
 
             var result = template(referral);

--- a/embc-app/Services/Referrals/ReferralsService.cs
+++ b/embc-app/Services/Referrals/ReferralsService.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Gov.Jag.Embc.Public.Utils;
 using System.Collections.Generic;
 using System.ComponentModel;
+using Microsoft.AspNetCore.Hosting;
 
 namespace Gov.Jag.Embc.Public.Services.Referrals
 {
@@ -16,14 +17,16 @@ namespace Gov.Jag.Embc.Public.Services.Referrals
         private readonly IDataInterface dataInterface;
         private readonly IPdfConverter pdfConverter;
         private readonly ICurrentUser userService;
+        private readonly IHostingEnvironment env;
 
         private readonly string pageBreak = $@"{Environment.NewLine}<div class=""page-break""></div>{Environment.NewLine}";
 
-        public ReferralsService(IDataInterface dataInterface, IPdfConverter pdfConverter, ICurrentUser currentUser)
+        public ReferralsService(IDataInterface dataInterface, IPdfConverter pdfConverter, ICurrentUser currentUser, IHostingEnvironment environment)
         {
             this.dataInterface = dataInterface;
             this.pdfConverter  = pdfConverter;
             this.userService   = currentUser;
+            this.env           = environment;
         }
 
         public async Task<byte[]> GetReferralPdfsAsync(ReferralsToPrint printReferrals)
@@ -97,6 +100,9 @@ namespace Gov.Jag.Embc.Public.Services.Referrals
 
             
             referral.VolunteerDisplayName = userService.GetDisplayName();
+            // If we're in prod, we don't want the watermark
+            var foo = env.IsProduction(); // do this work????????
+            referral.DisplayWatermark = !env.IsProduction();
 
             var result = template(referral);
 

--- a/embc-app/Services/Referrals/Views/Css.hbs
+++ b/embc-app/Services/Referrals/Views/Css.hbs
@@ -536,4 +536,21 @@
     .page-break {
         page-break-after: always;
     }
+
+    .watermark {
+        transform: rotate(-70deg);
+        opacity: 0.5;
+        color: #ccc;
+        font-size: 10em;
+        font-weight: bold;
+        z-index: 5000;
+        position: absolute;
+        top: 10cm;
+        left: 0;
+        right: 0;
+        text-transform: uppercase;
+        word-wrap: break-word;
+    }
+
+
 </style>

--- a/embc-app/Services/Referrals/Views/Referral.hbs
+++ b/embc-app/Services/Referrals/Views/Referral.hbs
@@ -6,6 +6,11 @@
             Not redeemable for cash
         </p>
     </div>
+    {{#if DisplayWatermark}}
+    <div class="watermark">
+        Training Sample Only
+    </div>
+    {{/if}}
     <div class="volunteer-name">
         Volunteer: {{VolunteerDisplayName}}
     </div>

--- a/embc-app/Services/Referrals/Views/Referral.hbs
+++ b/embc-app/Services/Referrals/Views/Referral.hbs
@@ -30,7 +30,7 @@
             </div>
             <div class="col-6">
                 <div class="stamp-goes-here">
-                    <p>Place Stamp Here</p>
+                    
                 </div>
             </div>
         </div>

--- a/embc-app/ViewModels/PrintReferral.cs
+++ b/embc-app/ViewModels/PrintReferral.cs
@@ -108,6 +108,8 @@ namespace Gov.Jag.Embc.Public.ViewModels
         public string ApprovedItemsPrinted => ConvertCarriageReturnToHtml(ApprovedItems);
         // Not mapped, only used when printing a referral.
         public string VolunteerDisplayName { get; set; }
+        // Not mapped, flag that enables the TRAINING SAMPLE watermark if true
+        public bool DisplayWatermark { get; set; }
 
         public object[] PrintableEvacuees
         {


### PR DESCRIPTION
Combined changes for EMBCESSMOD-92 and 267
* Added TRAINING SAMPLE ONLY watermark for referrals printed on non-prod environments 
* Removed the 'Place Stamp Here' text to prevent riots when users discover there is no stamp to place there