### PR TITLE
Get meta data for active/inactive tasks in list

### DIFF
--- a/embc-app/ClientApp/src/app/core/models/open-and-closed-tasks-metadata.model.ts
+++ b/embc-app/ClientApp/src/app/core/models/open-and-closed-tasks-metadata.model.ts
@@ -1,0 +1,6 @@
+import { PaginationSummary } from './list-result';
+
+export interface OpenAndClosedTasksMetadata {
+    openTasks: PaginationSummary;
+    closedTasks: PaginationSummary;
+}

--- a/embc-app/ClientApp/src/app/core/services/incident-task.service.ts
+++ b/embc-app/ClientApp/src/app/core/services/incident-task.service.ts
@@ -7,6 +7,7 @@ import { CoreModule } from '../core.module';
 import { RestService } from './rest.service';
 import { HttpResponse } from '@angular/common/http';
 import { SearchQueryParameters } from '../models/search-interfaces';
+import { OpenAndClosedTasksMetadata } from '../models/open-and-closed-tasks-metaData.model';
 
 @Injectable({
   providedIn: CoreModule
@@ -50,6 +51,22 @@ export class IncidentTaskService extends RestService {
         retry(3),
         catchError(this.handleError)
       );
+  }
+
+  getOpenAndClosedIncidentTaskMetadata(props: SearchQueryParameters = {}): Observable<OpenAndClosedTasksMetadata> {
+    const { limit = 100, offset = 0, q = '', sort = '' } = props;
+    const params = {
+      limit: (limit || 100).toString(), // query params are strings
+      offset: (offset || 0).toString(),
+      q: q || '',
+      sort: sort || '',
+    };
+    
+    return this.http.get<OpenAndClosedTasksMetadata>('/api/incidenttasks/getOpenAndClosedIncidentTaskMetadata', {headers: this.headers, params})
+    .pipe(
+      retry(3),
+      catchError(this.handleError)
+    );
   }
 
   createIncidentTask(data: IncidentTask): Observable<IncidentTask> {

--- a/embc-app/ClientApp/src/app/provincial-admin/components/task-number-list/task-number-list.component.ts
+++ b/embc-app/ClientApp/src/app/provincial-admin/components/task-number-list/task-number-list.component.ts
@@ -6,6 +6,7 @@ import { IncidentTaskService } from 'src/app/core/services/incident-task.service
 import { SearchQueryParameters } from 'src/app/core/models/search-interfaces';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { UniqueKeyService } from 'src/app/core/services/unique-key.service';
+import { OpenAndClosedTasksMetadata } from 'src/app/core/models/open-and-closed-tasks-metaData.model';
 import * as moment from 'moment';
 
 @Component({
@@ -25,6 +26,9 @@ export class TaskNumberListComponent implements OnInit {
   // private variable holding all tasks so we can filter active/inactive on the client
   private allTasks: ListResult<IncidentTask>; 
   private taskArray: IncidentTask[] = [];
+  private openTasksPagination: PaginationSummary;
+  private closedTasksPagination: PaginationSummary;
+  
   constructor(
     private incidentTaskService: IncidentTaskService,
     private router: Router,
@@ -37,9 +41,10 @@ export class TaskNumberListComponent implements OnInit {
   get results(): IncidentTask[] {
     return this.taskArray;
   }
-  // TODO: This is probably broken now... we will need to know the # of active and inactive tasks
+
+  
   get pagination(): PaginationSummary {
-    return this.resultsAndPagination ? this.resultsAndPagination.metadata : null;
+    return this.showActiveTasks ? this.openTasksPagination : this.closedTasksPagination;
   }
 
   ngOnInit() {
@@ -50,6 +55,7 @@ export class TaskNumberListComponent implements OnInit {
 
     // collect all incident tasks
     this.getIncidentTasks();
+    this.getMetaData();
   }
 
   initSearchForm(): void {
@@ -68,6 +74,14 @@ export class TaskNumberListComponent implements OnInit {
       }, err => {
         console.log('error getting tasks =', err);
       });
+  }
+
+  private getMetaData() {
+    this.incidentTaskService.getOpenAndClosedIncidentTaskMetadata()
+      .subscribe((pageData: OpenAndClosedTasksMetadata) => {
+        this.openTasksPagination = pageData.openTasks;
+        this.closedTasksPagination = pageData.closedTasks;
+      })
   }
 
   filter(community: Community) {

--- a/embc-app/Controllers/IncidentTasksController.cs
+++ b/embc-app/Controllers/IncidentTasksController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -66,6 +67,20 @@ namespace Gov.Jag.Embc.Public.Controllers
             return Json(items);
         }
 
+        [HttpGet("getOpenAndClosedIncidentTaskMetadata")]
+        public async Task<IActionResult> GetOpenAndClosedIncidentTaskMetadata([FromQuery] SearchQueryParameters searchQuery)
+        {
+            int limit  = searchQuery.Limit;
+            int offset = searchQuery.Offset;
+            var result = new OpenAndClosedTasksMetadata
+            {
+                OpenTasks   = await dataInterface.GetOpenIncidentTasksMetadataAsync(limit, offset),
+                ClosedTasks = await dataInterface.GetClosedIncidentTasksMetadataAsync(limit, offset)
+            };
+
+            return Json(result);
+        }
+
         [HttpPost]
         public async Task<IActionResult> Create([FromBody] IncidentTask item)
         {
@@ -116,5 +131,13 @@ namespace Gov.Jag.Embc.Public.Controllers
             var result = await dataInterface.DeactivateIncidentTaskAsync(id);
             return Ok();
         }
+    }
+
+    public class OpenAndClosedTasksMetadata
+    {
+        [JsonProperty("openTasks")]
+        public PaginationMetadata OpenTasks { get; set; }
+        [JsonProperty("closedTasks")]
+        public PaginationMetadata ClosedTasks { get; set; }
     }
 }

--- a/embc-app/DataInterfaces/DataInterface.IncidentTask.cs
+++ b/embc-app/DataInterfaces/DataInterface.IncidentTask.cs
@@ -55,6 +55,40 @@ namespace Gov.Jag.Embc.Public.DataInterfaces
             return new PaginatedList<IncidentTask>(items.Select(i => mapper.Map<IncidentTask>(i)), offset, limit);
         }
 
+        public async Task<PaginationMetadata> GetOpenIncidentTasksMetadataAsync(int limit = 100, int offset = 0)
+        {
+            DateTime now = DateTime.UtcNow;
+            int count = await IncidentTasks
+                        .Where(i => i.Active && i.TaskNumberEndDate.HasValue && i.TaskNumberEndDate > now)
+                        .CountAsync();
+            // Build the meta data
+            var result = new PaginationMetadata()
+            {
+                CurrentPage = (int)Math.Floor((decimal)offset / limit) + 1,
+                PageSize = limit,
+                TotalCount = count,
+                TotalPages = (int)Math.Ceiling((decimal)count / limit)
+            };
+            return result;
+        }
+
+        public async Task<PaginationMetadata> GetClosedIncidentTasksMetadataAsync(int limit = 100, int offset = 0)
+        {
+            DateTime now = DateTime.UtcNow;
+            int count = await IncidentTasks
+                        .Where(i => i.Active && i.TaskNumberEndDate.HasValue && i.TaskNumberEndDate < now)
+                        .CountAsync();
+            // Build the meta data
+            var result = new PaginationMetadata()
+            {
+                CurrentPage = (int)Math.Floor((decimal)offset / limit) + 1,
+                PageSize = limit,
+                TotalCount = count,
+                TotalPages = (int)Math.Ceiling((decimal)count / limit)
+            };
+            return result;
+        }
+
         public async Task<IncidentTask> GetIncidentTaskByTaskNumbetAsync(string taskNumber)
         {
             var entity = await IncidentTasks

--- a/embc-app/DataInterfaces/IDataInterface.cs
+++ b/embc-app/DataInterfaces/IDataInterface.cs
@@ -36,6 +36,10 @@ namespace Gov.Jag.Embc.Public.DataInterfaces
 
         Task<IPagedResults<IncidentTask>> GetOpenIncidentTasksAsync(int limit = 100, int offset = 0);
 
+        Task<PaginationMetadata> GetOpenIncidentTasksMetadataAsync(int limit = 100, int offset = 0);
+
+        Task<PaginationMetadata> GetClosedIncidentTasksMetadataAsync(int limit = 100, int offset = 0);
+
         Task<IncidentTask> GetIncidentTaskByTaskNumbetAsync(string taskNumber);
 
         Task<string> CreateIncidentTaskAsync(IncidentTask task);


### PR DESCRIPTION
* Added methods to provide the pagination meta data for active/inactive tasks in the task list component (before it was just using the pagination info from the default incident task query)