### PR TITLE
Add code to remove duplicate results from evacuee search query

### DIFF
--- a/embc-app/DataInterfaces/DataInterface.Evacuee.cs
+++ b/embc-app/DataInterfaces/DataInterface.Evacuee.cs
@@ -3,6 +3,7 @@ using Gov.Jag.Embc.Public.ViewModels;
 using Gov.Jag.Embc.Public.ViewModels.Search;
 using Microsoft.EntityFrameworkCore;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -159,8 +160,14 @@ namespace Gov.Jag.Embc.Public.DataInterfaces
             // get results back from 
             var results = await pagedQuery.Query.Sort(MapSortToFields(searchQuery.SortBy)).ToArrayAsync();
 
+            // strip out any duplicates
+            // The view we are querying for evacuees returns duplicate results when dependants are included
+            // This should be fixed in the view
+            var distinct = results.ToList().Distinct<Models.Db.ViewEvacuee>();
+
+            
             // map the evacueeList
-            return new PaginatedList<EvacueeListItem>(results.Select(mapper.Map<EvacueeListItem>), pagedQuery.Pagination);
+            return new PaginatedList<EvacueeListItem>(distinct.Select(mapper.Map<EvacueeListItem>), pagedQuery.Pagination);
         }
 
         private string MapSortToFields(string sort)


### PR DESCRIPTION
I don't love how I did this, but it is a solution. Basically, the issue is that the view we query for evacuees (viewEvacuee) does not handle dependents properly and will return an extra result for every evacuee in that household. I've been fiddling with the view locally but I can't get it to not return these extra rows. In the interest of time, I fixed it by just removing all duplicates on the server. 

I don't think this is a great solution (we really should be able to trust the results from the database) but it fixes the bug and gives me time to smash my face against some Angular issues.

Thoughts/suggestions? 