### PR TITLE
Fix issue with active task not being set on registrations when editing

### DIFF
--- a/embc-app/ClientApp/src/app/core/models/index.ts
+++ b/embc-app/ClientApp/src/app/core/models/index.ts
@@ -14,3 +14,4 @@ export * from './relationship-type.model';
 export * from './supplier.model';
 export * from './user.model';
 export * from './volunteer.model';
+export * from './volunteer-task.model';

--- a/embc-app/Controllers/VolunteerTasksController.cs
+++ b/embc-app/Controllers/VolunteerTasksController.cs
@@ -85,9 +85,9 @@ namespace Gov.Jag.Embc.Public.Controllers
                 return BadRequest(ModelState);
             }
 
-            var volunteerId = HttpContext.User.FindFirstValue(EssClaimTypes.USER_ID);
+            var volunteerId = int.Parse(userService.CurrentUser.contactid);
             // get volunteerTask by volunteer id
-            var volunteerTask = await dataInterface.GetVolunteerTaskByVolunteerIdAsync(int.Parse(volunteerId));
+            var volunteerTask = await dataInterface.GetVolunteerTaskByVolunteerIdAsync(volunteerId);
 
             var sessionTimeout = configuration.ServerTimeoutInMinutes();
 

--- a/embc-app/DataInterfaces/DataInterface.VolunteerTask.cs
+++ b/embc-app/DataInterfaces/DataInterface.VolunteerTask.cs
@@ -37,8 +37,13 @@ namespace Gov.Jag.Embc.Public.DataInterfaces
 
           public async Task<VolunteerTask> GetVolunteerTaskByVolunteerIdAsync(int volunteerId)
         {
-            var volunteerTask = await VolunteerTasks.SingleOrDefaultAsync(v => v.Volunteer.Id == volunteerId);
-            return mapper.Map<VolunteerTask>(volunteerTask);
+            //var volunteerTask = await VolunteerTasks.SingleOrDefaultAsync(v => v.VolunteerId == volunteerId);
+            //return mapper.Map<VolunteerTask>(volunteerTask);
+            // Get the most recent record in volunteer tasks with the volunteer Id
+            var vTask = await VolunteerTasks.Where(vt => vt.VolunteerId == volunteerId)
+                            .OrderByDescending(vt => vt.LastDateVolunteerConfirmedTask)
+                            .FirstAsync();
+            return mapper.Map<VolunteerTask>(vTask);
         }
 
         public async Task<VolunteerTask> CreateVolunteerTaskAsync(VolunteerTask newVolunteerTask)

--- a/embc-app/DataInterfaces/DataInterface.VolunteerTask.cs
+++ b/embc-app/DataInterfaces/DataInterface.VolunteerTask.cs
@@ -37,8 +37,6 @@ namespace Gov.Jag.Embc.Public.DataInterfaces
 
           public async Task<VolunteerTask> GetVolunteerTaskByVolunteerIdAsync(int volunteerId)
         {
-            //var volunteerTask = await VolunteerTasks.SingleOrDefaultAsync(v => v.VolunteerId == volunteerId);
-            //return mapper.Map<VolunteerTask>(volunteerTask);
             // Get the most recent record in volunteer tasks with the volunteer Id
             var vTask = await VolunteerTasks.Where(vt => vt.VolunteerId == volunteerId)
                             .OrderByDescending(vt => vt.LastDateVolunteerConfirmedTask)


### PR DESCRIPTION
Fixed a bug where the registration form wasn't being populated with the active task of the ERA User when they were editing a registration. Also fixed a bug with the GetVolunteerTaskByVolunteerAsync method.