### PR TITLE
Embcessmod 320 prevent duplicate task nums

### DIFF
--- a/embc-app/ClientApp/src/app/core/services/incident-task.service.ts
+++ b/embc-app/ClientApp/src/app/core/services/incident-task.service.ts
@@ -83,4 +83,13 @@ export class IncidentTaskService extends RestService {
         catchError(this.handleError)
       );
   }
+
+  isTaskNumberUnique(taskNum: string): Observable<boolean> {
+    return this.http.get<boolean>('/api/incidenttasks/getIsUniqueTaskNumber/' + taskNum, {headers: this.headers})
+    .pipe(
+      retry(3),
+      catchError(this.handleError)
+    );
+  }
+
 }

--- a/embc-app/ClientApp/src/app/provincial-admin/components/task-number-maker/task-number-maker.component.html
+++ b/embc-app/ClientApp/src/app/provincial-admin/components/task-number-maker/task-number-maker.component.html
@@ -10,8 +10,10 @@
       <div class="row">
         <div class="col mb-4">
           <label class="required" for="taskNumber">Task Number</label>
-          <input type="text" class="form-control" [class.is-invalid]="invalid('taskNumber')" formControlName="taskNumber" id="taskNumber">
+          <input type="text" class="form-control" [class.is-invalid]="invalid('taskNumber')" 
+          formControlName="taskNumber" id="taskNumber" (blur)="taskNumberBlur()">
           <span class="invalid-feedback">Please enter a task number</span>
+          <span *ngIf="!taskNumberIsUnique" class="taken-task-num-error">The Task Number you entered already exists in the system, please enter a unique number</span>
         </div>
       </div>
       <div class="row">

--- a/embc-app/ClientApp/src/app/provincial-admin/components/task-number-maker/task-number-maker.component.scss
+++ b/embc-app/ClientApp/src/app/provincial-admin/components/task-number-maker/task-number-maker.component.scss
@@ -19,3 +19,10 @@ app-date-time-picker {
 .start-date-text {
   font-size: 1.2em;
 }
+
+.taken-task-num-error {
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 80%;
+  color: #d93e45;
+}

--- a/embc-app/ClientApp/src/app/provincial-admin/components/task-number-maker/task-number-maker.component.ts
+++ b/embc-app/ClientApp/src/app/provincial-admin/components/task-number-maker/task-number-maker.component.ts
@@ -29,6 +29,7 @@ export class TaskNumberMakerComponent implements OnInit, AfterViewInit, OnDestro
   submitting = false;
   path: string = null; // the base path for routing
   endDateOverride: boolean = false; 
+  taskNumberIsUnique: boolean = true;
   overrideDate: Date = null;
   // Subscription for the taskNumberStartDate control's value change event
   // Whenever the start date's value is changed we need to update the validator
@@ -176,7 +177,7 @@ export class TaskNumberMakerComponent implements OnInit, AfterViewInit, OnDestro
     this.showErrorsWhen = true;
 
     // proceed if form is valid
-    if (this.form.valid) {
+    if (this.form.valid && this.taskNumberIsUnique) {
       // show the review part of the form
       this.maker = false;
       this.onMakeView.emit(this.maker);
@@ -262,6 +263,14 @@ export class TaskNumberMakerComponent implements OnInit, AfterViewInit, OnDestro
       });
       this.overrideDate = minEndDate.toDate();
     }
+  }
+
+  taskNumberBlur(): void {
+    const taskNum: string = this.form.get("taskNumber").value as string;
+    // Don't do anything if tasknumber is empty
+    if (taskNum == null || taskNum === '') {return;}
+    this.incidentTaskService.isTaskNumberUnique(taskNum)
+      .subscribe(result => this.taskNumberIsUnique = result);
   }
 
   cancel() {

--- a/embc-app/Controllers/IncidentTasksController.cs
+++ b/embc-app/Controllers/IncidentTasksController.cs
@@ -81,6 +81,13 @@ namespace Gov.Jag.Embc.Public.Controllers
             return Json(result);
         }
 
+        [HttpGet("getIsUniqueTaskNumber/{taskNum}")]
+        public async Task<IActionResult> GetIsUniqueTaskNumber(string taskNum)
+        {
+            bool result = await dataInterface.IsUniqueTaskNumber(taskNum);
+            return Json(result);
+        }
+
         [HttpPost]
         public async Task<IActionResult> Create([FromBody] IncidentTask item)
         {

--- a/embc-app/DataInterfaces/DataInterface.IncidentTask.cs
+++ b/embc-app/DataInterfaces/DataInterface.IncidentTask.cs
@@ -122,5 +122,12 @@ namespace Gov.Jag.Embc.Public.DataInterfaces
 
             return true;
         }
+
+        public async Task<bool> IsUniqueTaskNumber(string taskNumber)
+        {
+            bool isTaken = await IncidentTasks.AnyAsync(task =>
+                string.Equals(taskNumber, task.TaskNumber, StringComparison.InvariantCultureIgnoreCase));
+            return !isTaken;
+        }
     }
 }

--- a/embc-app/DataInterfaces/IDataInterface.cs
+++ b/embc-app/DataInterfaces/IDataInterface.cs
@@ -48,6 +48,8 @@ namespace Gov.Jag.Embc.Public.DataInterfaces
 
         Task<bool> DeactivateIncidentTaskAsync(string id);
 
+        Task<bool> IsUniqueTaskNumber(string taskNumber);
+
         #endregion Incident task
 
         #region Lookup data


### PR DESCRIPTION
* Added GetIsUniqueTaskNumber to IncidentTasksController 
* Client now calls the new function on blur of Task Number field when creating/editing a task number
