### PR TITLE
Only require PrimaryContact for super users if current user is an admin

### DIFF
--- a/embc-app/ClientApp/src/app/provincial-admin/components/admin-volunteer-maker/admin-volunteer-maker.component.ts
+++ b/embc-app/ClientApp/src/app/provincial-admin/components/admin-volunteer-maker/admin-volunteer-maker.component.ts
@@ -73,9 +73,9 @@ export class AdminVolunteerMakerComponent implements OnInit {
       isPrimaryContact: ['']
     });
 
-    // validate isPrimaryContact only if isAdministrator is true
+    // validate isPrimaryContact only if isAdministrator is true and user is admin
     this.form.controls.isAdministrator.valueChanges.subscribe(value => {
-      if (value) {
+      if (value && this.iAmProvincialAdmin) {
         this.f.isPrimaryContact.setValidators([Validators.required]);
       } else {
         this.f.isPrimaryContact.clearValidators();
@@ -101,7 +101,7 @@ export class AdminVolunteerMakerComponent implements OnInit {
           .subscribe((organization: Organization) => {
             this.currentOrganization = organization;
             this.doSelectOrg = false;
-
+            this.form.get("")
             // continue
             this.ngOnInit2();
           }, err => {

--- a/embc-app/ClientApp/src/app/provincial-admin/components/admin-volunteer-maker/admin-volunteer-maker.component.ts
+++ b/embc-app/ClientApp/src/app/provincial-admin/components/admin-volunteer-maker/admin-volunteer-maker.component.ts
@@ -101,7 +101,6 @@ export class AdminVolunteerMakerComponent implements OnInit {
           .subscribe((organization: Organization) => {
             this.currentOrganization = organization;
             this.doSelectOrg = false;
-            this.form.get("")
             // continue
             this.ngOnInit2();
           }, err => {


### PR DESCRIPTION
Fixes bug in embcessmod-251 where Superusers could not add other Superusers because they could never fill out the required, hidden input.